### PR TITLE
add github action workflow for automatic build and deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: _build/html/
+          FOLDER: mini_book/_build/html/
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,6 +13,7 @@ jobs:
         uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: true
+          auto-activate-base: false
           miniconda-version: 'latest'
           python-version: 3.7
           environment-file: environment.yml
@@ -23,10 +24,11 @@ jobs:
 
       - name: Build QuantEcon Mini Example
         run: jb build mini_book/
-        
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: _build/html/
+

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
 on: [push]
+  push:
+    branches:
+      - master
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -34,3 +37,32 @@ jobs:
           BRANCH: gh-pages
           FOLDER: mini_book/_build/html/
 
+
+name: Test Build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: quantecon-mini-example
+          
+      - name: Install jupyter_book
+        shell: bash -l {0}
+        run: pip install git+https://github.com/ExecutableBookProject/cli.git@master
+
+      - name: Build QuantEcon Mini Example
+        shell: bash -l {0}
+        run: jb build mini_book/

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,32 @@
+name: Build and Deploy
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: quantecon-mini-example
+          
+      - name: Install jupyter_book
+        run: pip install git+https://github.com/ExecutableBookProject/cli.git@master
+
+      - name: Build QuantEcon Mini Example
+        run: jb build mini_book/
+        
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: _build/html/

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,9 +20,11 @@ jobs:
           activate-environment: quantecon-mini-example
           
       - name: Install jupyter_book
+        shell: bash -l {0}
         run: pip install git+https://github.com/ExecutableBookProject/cli.git@master
 
       - name: Build QuantEcon Mini Example
+        shell: bash -l {0}
         run: jb build mini_book/
 
       - name: Deploy 🚀

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,5 +1,5 @@
 name: Build and Deploy
-on: [push]
+on:
   push:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,7 @@
-name: Build and Deploy
+name: Test Build
 on: [push]
-  push:
-    branches:
-      - master
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -29,10 +26,3 @@ jobs:
       - name: Build QuantEcon Mini Example
         shell: bash -l {0}
         run: jb build mini_book/
-
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: mini_book/_build/html/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Test Build
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - python
   - matplotlib
+  - pathlib
   - pip:
     - quantecon
  

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,5 @@ dependencies:
   - python
   - matplotlib
   - pip:
-    - pathlib
     - quantecon
  

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: quantecon-mini-example
+channels:
+  - default
+  - conda-forge
+dependencies:
+  - pip
+  - python
+  - matplotlib
+  - pip:
+    - quantecon
+ 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - python
   - matplotlib
-  - pathlib
   - pip:
+    - pathlib
     - quantecon
  


### PR DESCRIPTION
@najuzilu @jstac this PR introduces automatic building and deployment to `gh-pages` branch for this example project. There are two defined workflows:

`build.yml` -> builds the project on **any** push including PR's to test the build using `jupyter_book`
`build-and-deploy.yml` -> builds the project and deploys when a push action is done on `master` (i.e. merging a PR, or pushing directly to master)