### PR TITLE
remove toc header

### DIFF
--- a/mini_book/_toc.yml
+++ b/mini_book/_toc.yml
@@ -1,8 +1,7 @@
 # - file: README
 - file: docs/index
-
-- header: Scientific Python Quickstart
-- file: docs/about_py
-- file: docs/getting_started
-- file: docs/python_by_example
-- file: docs/learn_more
+  sections:
+    - file: docs/about_py
+    - file: docs/getting_started
+    - file: docs/python_by_example
+    - file: docs/learn_more


### PR DESCRIPTION
Slight modification of sidebar header. The current published version has a file with the same title as the header (see below).

We should also use this PR to test gh worflow @mmcky.

<img width="267" alt="Screen Shot 2020-04-22 at 8 55 26 PM" src="https://user-images.githubusercontent.com/33075058/79973837-9920f680-84db-11ea-8e36-11cb84b467e7.png">
