### PR TITLE
rename conda env & update cli to jupyter-book

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,11 +20,11 @@ jobs:
           miniconda-version: 'latest'
           python-version: 3.7
           environment-file: environment.yml
-          activate-environment: quantecon-mini-example
-          
+          activate-environment: qe-mini-example
+
       - name: Install jupyter_book
         shell: bash -l {0}
-        run: pip install git+https://github.com/ExecutableBookProject/cli.git@master
+        run: pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master
 
       - name: Build QuantEcon Mini Example
         shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
           miniconda-version: 'latest'
           python-version: 3.7
           environment-file: environment.yml
-          activate-environment: quantecon-mini-example
-          
+          activate-environment: qe-mini-example
+
       - name: Install jupyter_book
         shell: bash -l {0}
-        run: pip install git+https://github.com/ExecutableBookProject/cli.git@master
+        run: pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master
 
       - name: Build QuantEcon Mini Example
         shell: bash -l {0}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,11 +19,11 @@ jobs:
           miniconda-version: 'latest'
           python-version: 3.7
           environment-file: environment.yml
-          activate-environment: quantecon-mini-example
+          activate-environment: qe-mini-example
 
       - name: Install jupyter_book
         shell: bash -l {0}
-        run: pip install git+https://github.com/ExecutableBookProject/cli.git@master
+        run: pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master
 
       - name: Build QuantEcon Mini Example
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: quantecon-mini-example
+name: qe-mini-example
 channels:
   - default
   - conda-forge


### PR DESCRIPTION
Changed conda env name from `quantecon-mini-example` to `qe-mini-example`.
Also, updated run to pull from `jupyter-book` since `cli` has been depreciated. 