### PR TITLE
fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A short example showing how to write a lecture series using Jupyter Book 2.0.
 ## Creating an environment
 
 1. `conda env create -f environment.yml`
-2. `conda activte quantecon-mini-example`
+2. `conda activate qe-mini-example`
 
 ## Building a Jupyter Book
-Run the following command in your terminal: `jb build book/`. If you would like to work with a clean build, you can empty the build folder by running `jb clean book/`. If the jupyter execution is cached, this command will not delete the cached folder. To remove the build folder, you can run `jb clean --all book/`.
+Run the following command in your terminal: `jb build mini_book/`. If you would like to work with a clean build, you can empty the build folder by running `jb clean mini_book/`. If the jupyter execution is cached, this command will not delete the cached folder. To remove the build folder, you can run `jb clean --all mini_book/`.
 
 ## Publishing this Jupyter Book
 
-Run `ghp-import -n -p -f book/_build/html`.
-If you are working on improving the quantecon-example, the publishing of your work is taken care by Github workflows.
+Run `ghp-import -n -p -f mini_book/_build/html`.
+If you are working on improving the quantecon-mini-example, the publishing of your work is taken care by Github workflows.


### PR DESCRIPTION
This PR fixes the following typos in the `readme.md` file:
- mistyped `activte` which has been updated to `activate`
- updated conda environment name from `quantecon-mini-example` to `qe-mini-example` which is compatible with the Github workflow
- update path to book from `book/` to `mini_book/`

The PR can be used to address issue #18.
