### PR TITLE
name latex output as book.pdf

### DIFF
--- a/mini_book/_config.yml
+++ b/mini_book/_config.yml
@@ -34,3 +34,5 @@ binder:
 
 latex:
   latex_engine                : "xelatex"
+  latex_documents:
+    targetname: book.tex


### PR DESCRIPTION
this will include an additional test of `latex_documents` configuration item

the produce `pdf` file using `latex` builder will now be called `boook.pdf`