### PR TITLE
Fix comment for description key on _config.yml

### DIFF
--- a/mini_book/_config.yml
+++ b/mini_book/_config.yml
@@ -4,7 +4,7 @@ title : Scientific Python QuickStart
 author: Thomas J. Sargent and John Stachurski
 logo: 'qe-logo-large.png'
 
-# Information about where the book exists on the web
+# Short description about the book
 description: >-
   A brief introduction to Python programming for scientific applications.
 


### PR DESCRIPTION
The initial comment was actually for the repository key according to the basic template made from `jupyter-book create` 
Since this repo is for beginners who wants to learn jupyter-book, I think unrelevant comments can actually confuse them.
I've changed the comment that I think is more relevant for the description key. 