### PR TITLE
Update Github Actions to use apt for latex

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -13,25 +13,22 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
       - name: Install Fonts
         run: |
           sudo apt-get install -y fonts-liberation
           sudo apt-get install -y fonts-cmu
-      - name: TexLive Cache
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: /tmp/texlive
-          key: cache-texlive
       - name: Install & Update TexLive
         shell: bash -l {0}
         run: |
-          bash scripts/install_latex.sh
-          echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> ~/.bash_profile
-          source ~/.bash_profile
-          xelatex --version
-
+          sudo apt-get -qq update
+          sudo apt-get install -y     \
+            texlive-latex-recommended \
+            texlive-latex-extra       \
+            texlive-fonts-recommended \
+            texlive-fonts-extra       \
+            texlive-xetex             \
+            latexmk                   \
+            xindy
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -41,18 +38,10 @@ jobs:
           python-version: 3.8
           environment-file: environment.yml
           activate-environment: qe-mini-example
-
-      - name: Install jupyter_book
-        shell: bash -l {0}
-        run: pip install git+https://github.com/ExecutableBookProject/jupyter-book.git@master
-
       - name: Build QuantEcon Mini Example
         shell: bash -l {0}
         run: |
-          echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> ~/.bash_profile
-          source ~/.bash_profile
           jb build mini_book/ --builder pdflatex
-
       - uses: actions/upload-artifact@v2
         with:
           name: pdf


### PR DESCRIPTION
This PR updates the `pdf` github actions workflow to use `apt-get` for installation of `texlive` to improve stability. 